### PR TITLE
changing new session title to "accede"

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row justify-content-center">
     <div class="col-md-6">
-      <h2>Entrar en tu cuenta</h2>
+      <h2>Accedé</h2>
 
 <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="form-inputs">


### PR DESCRIPTION
Cambié el titulo de: "Entrar a tu cuenta" por "Accedé" para obtener una página mas liviana y directa sin saturar con texto innecesariamente explicativo.